### PR TITLE
bugfix: MediaPrepController.ps1

### DIFF
--- a/MediaPrepController.ps1
+++ b/MediaPrepController.ps1
@@ -22,7 +22,7 @@ if ($directories.count -gt 0)
         }
         else
         {
-            & $PSScriptRoot\Remove-Subtitles.ps1 -Path $_.FullName
+            & $PSScriptRoot\Rename-Subtitles.ps1 -Path $_.FullName
         }
     }
 }


### PR DESCRIPTION
fixed the media prep controller script not properly renaming subtitles